### PR TITLE
Fix some Markdown code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,13 @@ During that console session the web UI would be interactively crossing items off
 #### `--web-only`, `--open`, `--no-cli`
 
 Start a list, open it in your browser, and skip the CLI interaction
+
     $ check start groceries --live --web-only --open
     $ check start groceries --live --no-cli -O
     Live at URL: http://checkcheckit.herokuapp.com/4f24b9d933d5467ec913461b8da3f952dbe724cb
 
 Run commands from the checklist
+
     $ cat ./hello.txt
     - say hello
         `echo hello`


### PR DESCRIPTION
Fixes a few blocks of shell examples under Options that were running together with previous plain text.

Rendered Markdown _before_:

![screen shot 2015-03-03 at 4 17 15 pm](https://cloud.githubusercontent.com/assets/66427/6475582/ca4d3dd8-c1c0-11e4-9100-8ea612c0a8e8.png)

Rendered Markdown _after_:

![screen shot 2015-03-03 at 4 18 09 pm](https://cloud.githubusercontent.com/assets/66427/6475594/f0032344-c1c0-11e4-91a5-a6adf1df2414.png)

Thanks for checkcheckit! :)
